### PR TITLE
Big overhaul with configurable chamber count & 'revolver' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,19 @@ which it prompts you.
 
 ### Available options
 
-* `timeout`: How long in seconds each user must wait between games
+This plugin's default settings ("random" `mode` with 6 `chambers` and a
+600-second `timeout`) mimic the source mIRC script, but the values are
+customizable as described here:
+
+* `chambers`: 6 by default\
+  How many chambers the revolver cylinder has. The chance of losing is
+  `1/chambers`.
+* `mode`: `random` (the default) or `revolver`
+  * In `random` mode, winning is a simple dice roll, `1 == randint(1, chambers)`.
+  * In `revolver` mode, the game places the bullet in a specific chamber (per
+  channel) and advances it each time someone plays.
+* `timeout`: 600 by default\
+  Cooldown in seconds between games, for each user.
 
 ## Using
 

--- a/sopel_roulette/plugin.py
+++ b/sopel_roulette/plugin.py
@@ -81,15 +81,17 @@ def play_revolver(bot: Sopel, trigger: Trigger) -> bool:
     chamber = bot.db.get_channel_value(
         channel,
         'roulette_bullet_pos',
-        random.randint(1, bot.settings.roulette.chambers),
     )
+    if chamber is None:
+        chamber = random.randint(1, bot.settings.roulette.chambers)
+        bot.action("loads a new bullet and spins the cylinder")
+        time.sleep(1)  # simulate a brief wait for the spinning to finish
 
-    chamber -= 1
     if chamber <= 1:
         bot.db.delete_channel_value(channel, 'roulette_bullet_pos')
         won = False
     else:
-        bot.db.set_channel_value(channel, 'roulette_bullet_pos', chamber)
+        bot.db.set_channel_value(channel, 'roulette_bullet_pos', chamber - 1)
         won = True
 
     return won

--- a/sopel_roulette/plugin.py
+++ b/sopel_roulette/plugin.py
@@ -6,60 +6,130 @@ Copyright (c) 2015-2025 dgw
 
 Licensed under the Eiffel Forum License 2
 """
-
 from __future__ import annotations
 
 import math
 import random
 import time
+from typing import TYPE_CHECKING
 
-from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel import plugin, tools
+from sopel.config import types
 
 
-class RouletteSection(StaticSection):
-    timeout = ValidatedAttribute('timeout', int, default=600)
-    """The timeout (in seconds) between roulette trigger pulls by the same user."""
+if TYPE_CHECKING:
+    from sopel.bot import Sopel
+    from sopel.config import Config
+    from sopel.trigger import Trigger
 
 
-def configure(config):
+class RouletteSection(types.StaticSection):
+    mode = types.ChoiceAttribute(
+        'mode',
+        ['random', 'revolver'],
+        default='random',
+    )
+    """The game mode.
+
+    - `random`: winning is based solely on a random number generator.
+    - `revolver`: the bullet is loaded into a random chamber and the revolver
+      advances one slot after each trigger pull.
+    """
+
+    chambers = types.ValidatedAttribute(
+        'chambers',
+        int,
+        str,
+        default=6,
+    )
+    """How many chambers the revolver has — 6 by default.
+
+    The chance of losing is the reciprocal of this number.
+    """
+
+    timeout = types.ValidatedAttribute('timeout', int, default=600)
+    """The timeout (in seconds) between games of roulette by the same user."""
+
+
+def configure(config: Config) -> None:
     config.define_section('roulette', RouletteSection)
     config.roulette.configure_setting(
+        'mode',
+        'Game mode ({}):'.format(', '.join(RouletteSection.mode.choices)),
+    )
+    config.roulette.configure_setting(
+        'chambers',
+        'Number of chambers in the revolver (default: 6):',
+    )
+    config.roulette.configure_setting(
         'timeout',
-        'Timeout between roulette trigger pulls by the same user (in seconds): ',
+        'Timeout between roulette trigger pulls by the same user (in seconds):',
     )
 
 
-def setup(bot):
-    bot.config.define_section('roulette', RouletteSection)
+def setup(bot: Sopel) -> None:
+    bot.settings.define_section('roulette', RouletteSection)
+
+
+def play_revolver(bot: Sopel, trigger: Trigger) -> bool:
+    """Play a round of Russian roulette with a revolver.
+
+    Each channel has a revolver with 6 chambers, and the bullet is loaded into
+    one at random. The revolver advances one slot after each trigger pull.
+    """
+    channel = trigger.sender
+    chamber = bot.db.get_channel_value(
+        channel,
+        'roulette_bullet_pos',
+        random.randint(1, bot.settings.roulette.chambers),
+    )
+
+    chamber -= 1
+    if chamber <= 1:
+        bot.db.delete_channel_value(channel, 'roulette_bullet_pos')
+        won = False
+    else:
+        bot.db.set_channel_value(channel, 'roulette_bullet_pos', chamber)
+        won = True
+
+    return won
 
 
 @plugin.command('roulette')
 @plugin.require_chanmsg
-def roulette(bot, trigger):
+def roulette(bot: Sopel, trigger: Trigger) -> None | int:
+    settings = bot.settings.roulette
     time_since = time_since_roulette(bot, trigger.nick)
-    if time_since < bot.config.roulette.timeout:
+    if time_since < settings.timeout:
         bot.notice(
             "Next roulette attempt will be available {}.".format(
                 tools.time.seconds_to_human(
-                    -(bot.config.roulette.timeout - time_since)
+                    -(settings.timeout - time_since)
                 )
             ),
             trigger.nick,
         )
         return plugin.NOLIMIT
-    if 6 != random.randint(1, 6):
-        won = True
+
+    if settings.mode == 'random':
+        won = random.randint(1, settings.chambers) == 1
+    elif settings.mode == 'revolver':
+        won = play_revolver(bot, trigger)
+    else:
+        bot.reply("Unknown roulette mode '%s'." % settings.mode)
+        return plugin.NOLIMIT
+
+    if won:
         bot.say("Click! %s is lucky; there was no bullet." % trigger.nick)
     else:
-        won = False
         bot.say("BANG! %s is dead!" % trigger.nick)
+
     bot.db.set_nick_value(trigger.nick, 'roulette_last', time.time())
     update_roulettes(bot, trigger.nick, won)
 
 
 @plugin.commands('roulettes', 'r')
-def roulettes(bot, trigger):
+def roulettes(bot: Sopel, trigger: Trigger) -> None | int:
     target = trigger.group(3) or trigger.nick
     games, wins = get_roulettes(bot, target)
     if not games:
@@ -72,7 +142,8 @@ def roulettes(bot, trigger):
     )
 
 
-def update_roulettes(bot, nick, won=False):
+def update_roulettes(bot: Sopel, nick: str, won: bool = False) -> None:
+    """Update the number of roulette games played and won by the user."""
     games, wins = get_roulettes(bot, nick)
     games += 1
     if won:
@@ -81,13 +152,15 @@ def update_roulettes(bot, nick, won=False):
     bot.db.set_nick_value(nick, 'roulette_wins', wins)
 
 
-def get_roulettes(bot, nick):
+def get_roulettes(bot: Sopel, nick: str) -> tuple[int, int]:
+    """Return the number of roulette games played and won by the user."""
     games = bot.db.get_nick_value(nick, 'roulette_games') or 0
     wins = bot.db.get_nick_value(nick, 'roulette_wins') or 0
     return games, wins
 
 
-def time_since_roulette(bot, nick):
+def time_since_roulette(bot: Sopel, nick: str) -> int:
+    """Return the time in seconds since the user's last roulette game."""
     now = time.time()
     last = bot.db.get_nick_value(nick, 'roulette_last') or 0
     return math.ceil(abs(now - last))


### PR DESCRIPTION
As it says in the summary:
* Added chamber count as a config setting
* Added a 'revolver' mode that picks a cylinder slot and advances it (saved per channel)

Other housekeeping:
* Added docstrings for helper functions
* Expanded on the README a little
* Added type annotations (unchecked with mypy, though)

This replaces #11